### PR TITLE
walletloader: Set Balance confirms to one.

### DIFF
--- a/cgo/sync.go
+++ b/cgo/sync.go
@@ -122,6 +122,17 @@ func syncWalletStatus(cName *C.char) *C.char {
 	}
 	targetHeight := spvSyncer.EstimateMainChainTip(ctx)
 
+	// Sometimes it appears we miss a notification during start up. This is
+	// a bandaid to put us as synced in that case.
+	//
+	// TODO: Figure out why we would miss a notification.
+	if w.IsSynced() {
+		w.syncStatusMtx.Lock()
+		ssc = SSCComplete
+		w.syncStatusCode = ssc
+		w.syncStatusMtx.Unlock()
+	}
+
 	ss := &SyncStatusRes{
 		SyncStatusCode: int(ssc),
 		SyncStatus:     ssc.String(),

--- a/cgo/walletloader.go
+++ b/cgo/walletloader.go
@@ -183,7 +183,8 @@ func walletBalance(cName *C.char) *C.char {
 		return errCResponse("wallet with name %q not loaded", goString(cName))
 	}
 
-	bals, err := w.AccountBalances(ctx, 0)
+	const confs = 1
+	bals, err := w.AccountBalances(ctx, confs)
 	if err != nil {
 		return errCResponse("w.AccountBalances error: %v", err)
 	}


### PR DESCRIPTION
If set to zero AccountBalances will bundle unconfirmed transactions into Spendable.