### PR TITLE
cgo: Return `vout` for transactions

### DIFF
--- a/cgo/transactions.go
+++ b/cgo/transactions.go
@@ -174,6 +174,7 @@ func listTransactions(cName, cFrom, cCount *C.char) *C.char {
 			Fee:           ltw.Fee,
 			Time:          ltw.Time,
 			TxID:          ltw.TxID,
+			Vout:          ltw.Vout,
 		}
 		ltRes[i] = lt
 	}

--- a/cgo/types.go
+++ b/cgo/types.go
@@ -136,6 +136,7 @@ type ListTransactionRes struct {
 	Fee           *float64 `json:"fee,omitempty"`
 	Time          int64    `json:"time"`
 	TxID          string   `json:"txid"`
+	Vout          uint32   `json:"vout"`
 }
 
 type BirthdayState struct {


### PR DESCRIPTION
This PR returns `vout` for transactions. We need this information to make unique keys when caching transactions using the `txid`. This is because multiple outputs in the same transaction will have the same `txid`.