### PR TITLE
dcr: Make addresses returns more useable.

### DIFF
--- a/cgo/types.go
+++ b/cgo/types.go
@@ -146,3 +146,9 @@ type BirthdayState struct {
 	SetFromHeight bool   `json:"setfromheight"`
 	SetFromTime   bool   `json:"setfromtime"`
 }
+
+type AddressesRes struct {
+	Used   []string `json:"used"`
+	Unused []string `json:"unused"`
+	Index  uint32   `json:"index"`
+}


### PR DESCRIPTION
We don't need the internal addresses for anything. Cake also tells me we need some more unused addresses. This adjusts the addresses output to be more useful for us.

Returning all the used addresses was also problematic for potentially having too many return values. 