### PR TITLE
sync: Recreate syncer every try.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,13 @@ jobs:
         go: ["1.22", "1.23"]
     steps:
       - name: Check out source
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Set up Go
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5.3.0
         with:
           go-version: ${{ matrix.go }}
       - name: Use lint cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
         with:
           path: |
             ~/.cache/golangci-lint

--- a/asset/dcr/transactions.go
+++ b/asset/dcr/transactions.go
@@ -262,5 +262,7 @@ func (w *Wallet) SendRawTransaction(ctx context.Context, txHex string) (*chainha
 	if err := msgTx.FromBytes(msgBytes); err != nil {
 		return nil, fmt.Errorf("unable to create msgtx from bytes: %v", err)
 	}
+	w.syncerMtx.RLock()
+	defer w.syncerMtx.RUnlock()
 	return w.mainWallet.PublishTransaction(ctx, msgTx, w.syncer)
 }

--- a/asset/dcr/wallet.go
+++ b/asset/dcr/wallet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sync"
 
 	"decred.org/dcrwallet/v4/spv"
 	"decred.org/dcrwallet/v4/wallet"
@@ -24,7 +25,8 @@ type Wallet struct {
 	db wallet.DB
 	*mainWallet
 
-	syncer *spv.Syncer
+	syncerMtx sync.RWMutex
+	syncer    *spv.Syncer
 }
 
 // MainWallet returns the main dcr wallet with the core wallet functionalities.


### PR DESCRIPTION
I think this is causing the background panic. Something forces sync to stop and when trying to restart with a synced wallet, it hits the closing closed channel panic. Run cannot be run twice on the same spv.Syncer.